### PR TITLE
Page for 2023-12-06

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting_setup.md
+++ b/.github/ISSUE_TEMPLATE/meeting_setup.md
@@ -21,6 +21,13 @@ sharing the room view.
 It is important that a calendar event is created and that a Google Meet link is included. Once created HTML for sharing
 the calendar event can be copy and pasted into the web-page that is created for the site and included in the mailing lists.
 
+## Web Page
+
+The [Reproducibilitea Sheffield Website](https://reproducibilitea-sheffield.github.io/) is a blog written in
+[Quarto](https://quarto.org). The [front-page of this
+repository](https://github.com/reproducibilitea-sheffield/reproducibilitea-sheffield.github.io) contains useful
+information on how to make a new post.
+
 ## Announcements
 
 Over time more places for announcing the event to will be added.
@@ -42,10 +49,12 @@ Please check off tasks as complete and fill in fields with details for reference
       Group](https://www.zotero.org/groups/2354006/reproducibilitea/library)).
   + **Paper** : [<TITLE>](<URL>)
 + [ ] Create new web-page detailing paper.
+  + [ ] Include a [OpenStreetMap](https://openstreetmap.org) link to the building location.
 + [ ] Create Google Calendar event with room details and link to web-page.
   + **Calendar Link** :
 + [ ] Announce to mailing lists...
   + [ ] [reproducibilitea-googlegroup@sheffield.ac.uk](mailto:reproducibilitea-googlegroup@sheffield.ac.uk)
   + [ ] [rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk)
   + [ ] Sheffield Hallam contact [Eddy Verban](mailto:E.Verbaan@shu.ac.uk) and [Pete Smith](mailto:P.R.Smith@shu.ac.uk)
-  + [ ] Add Postgraduate mailing lists.
+  + [ ] [myannouncement-students](https://staff.sheffield.ac.uk/marketing-comms/guidance/myannouncement-students) (see
+        the non-essential messaging section).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,57 @@
 This repository is the source code for the [Reproducibilitea Sheffield](https://Reproducibilitea-Sheffield.github.io)
 website.
 
+
+## Creating a new Post
+
+Typically you will have [booked a room](https://sites.google.com/sheffield.ac.uk/pooledroomdirectory/home) to hold the
+event in and if money is available for catering have organised that too.
+
+To create a new blog post you need to...
+
+1. Have a GitHub account and be added as a collaborator on the repository.
+2. Have cloned the repository locally.
+
+Once setup you can then...
+
+1. Ensure you are up-to-date with the `main` branch by `git pull`.
+2. Create a branch locally, typically using your GitHub username and the issue number and date makes it easy to see what
+   branches relate to, e.g. `ns-rse/2-dec-2023` was created by user `ns-rse`, it pertains to issue `2` which is about
+   the `dec-2023` meeting.
+3. Within the `posts` directory create a new sub-directory with the nomenclature `YYYY-MM` reflecting the year and month
+   the event will happen.
+4. Within the newly created directory create an `index.qmd` file.
+5. Open the `2023-12/index.qmd` and copy and paste the contents into your new file.
+6. Modify the `title`, `date` and `image` fields in the [YAML](https://yaml.org) header.
+7. Edit the body of text (everything from line 29 onwards) to reflect the meeting you are organising. Be sure to
+   include...
+   + A link to the original paper.
+   + The abstract as a Markdown quote.
+   + Details of who is providing the brief summary of the paper.
+   + Details of the room and building, with an [OpenStreetMap](https://openstreetmap.org) link to the building.
+   + To get the URL for Google Calendar for people to add easily...
+     1. Edit the event in the calendar and under _More actions_ select _Publish Event_.
+     2. Copy the _HTML code_ and paste it into the web-page.
+     3. Delete everything _except_ the URL that follows `href="` and everything after the closing double-quote.
+     4. Use this in the `[link]` on line 59.
+   + To get the Google Meet link
+     1. Edit the event in the calendar and under the _Join with Google Meet_ button is a URL.
+     2. Copy and paste this URL.
+     3. Paste and replace the URL on line 62 and prefix it with `https://` i.e. it should read similar to `[Google
+        Meet](https://meet.google.com/ehu-zapk-awt)`.
+
+### Images
+
+It can be useful to include openly licensed images in the web-page. These can be linked to directly if the image is on
+the internet.
+
+### Location Links
+
+Trying to stick with the Open Source theme, links to building locations can be provided using
+[OpenStreetMap](https://www.openstreetmap.org). Navigate, via zooming in, to the location of the building and
+right-click on the map and select "_Center map here_" and you can then copy the URL ("_Ctrl + l_" followed by "_Ctrl +
+c_" in most browsers) and paste that into the web-page you are creating.
+
 ## Links
 
 + [Reproducibilitea Sheffield Mailing List](https://groups.google.com/a/sheffield.ac.uk/g/reproducibilitea)

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,5 +16,5 @@ website:
         rel: me
 format:
   html:
-    theme: vapor
+    theme: darkly
     css: styles.css

--- a/posts/2023-12/index.qmd
+++ b/posts/2023-12/index.qmd
@@ -1,0 +1,63 @@
+---
+title: "Reproducibilitea 2023-12-06"
+date: "2023-12-06"
+categories: [reproducibilitea, reproducibility, sheffield]
+image: https://the-turing-way.netlify.app/_images/reproducibility.jpg
+from: markdown+emoji
+toc: true
+toc-depth: 4
+toc-location: right
+execute:
+  code_fold: true
+  code_link: true
+  code_tools: true
+  fig-cap-location: top
+  tbl-cap-location: top
+  warning: false
+---
+
+
+![The Turing Way project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807)](https://the-turing-way.netlify.app/_images/reproducibility.jpg)
+
+## What
+
+The chosen article to that we review and discuss is a recent publication _Nature Human Behaviour_
+
++ Protzko, J., Krosnick, J., Nelson, L. et al. High replicability of newly discovered social-behavioural findings is
+  achievable. Nat Hum Behav (2023). [doi : 10.1038/s41562-023-01749-9](https://doi.org/10.1038/s41562-023-01749-9)
+
+> Failures to replicate evidence of new discoveries have forced scientists to ask whether this unreliability is due to
+> suboptimal implementation of methods or whether presumptively optimal methods are not, in fact, optimal. This paper
+> reports an investigation by four coordinated laboratories of the prospective replicability of 16 novel experimental
+> findings using rigour-enhancing practices: confirmatory tests, large sample sizes, preregistration and methodological
+> transparency. In contrast to past systematic replication efforts that reported replication rates averaging 50%,
+> replication attempts here produced the expected effects with significance testing (P < 0.05) in 86% of attempts,
+> slightly exceeding the maximum expected replicability based on observed effect sizes and sample sizes. When one lab
+> attempted to replicate an effect discovered by another lab, the effect size in the replications was 97% that in the
+> original study. This high replication rate justifies confidence in rigour-enhancing methods to increase the
+> replicability of new discoveries.
+
+Neil Shephard (Research Software Engineer at University of Sheffield) will give a brief summary of the article and will
+open discussion by highlighting some of the points he thought were good/bad about the paper.
+
+
+## Where
+
+This event will be hybrid, if you wish to attend in person we will be meeting in Workroom 2 of [The Diamond, 32
+Leavygreave Road, Sheffield, Broomhall, S3 7RD](https://www.openstreetmap.org/#map=19/53.38172/-1.48222).
+
+Add the event to your Google Calendar using this
+[link](https://calendar.google.com/calendar/event?action=TEMPLATE&amp;tmeid=MjU3NmE5dWlpbHUydTQ0Y2YzOWFzYmdkM2ggbi5zaGVwaGFyZEBzaGVmZmllbGQuYWMudWs&amp;tmsrc=n.shephard%40sheffield.ac.uk).
+
+If you aren't able to attend in person but would like to join the Journal Club you can do so using [Google
+Meet](https://meet.google.com/ehu-zapk-awt).
+
+## When
+
+2023-12-06 @ 13:15 Sheffield Reproducibilitea Journal Club is back in time to see 2023 out.
+
+## Future Events
+
+To stay abreast of up-coming events you can either sign up to the [mailing
+list](https://groups.google.com/a/sheffield.ac.uk/g/reproducibilitea) or subscribe to the [RSS
+feed](https://reproducibilitea-sheffield.github.io/index.xml).

--- a/posts/reboot/index.qmd
+++ b/posts/reboot/index.qmd
@@ -14,17 +14,6 @@ execute:
   fig-cap-location: top
   tbl-cap-location: top
   warning: false
-about:
-  template: jolla
-  links:
-    - icon: github
-      text: Github
-      href: https://github.com/Reproducibilitea-Sheffield
-      rel: me
-    - icon: mastodon
-      text: Mastodon
-      href: https://fosstodon.org/@reproducibilitea-sheffield
-      rel: me
 ---
 
 Reproducibilitea Sheffield is back!


### PR DESCRIPTION
Closes #2

+ Theme from `vapor` > `darkly` in  `_quarto.yaml`
+ Tweaks to the `.github/ISSUE_TEMPLATE/meeting_setup.md`
+ Adds instructions for creating a post to `README.md`
+ Removes `about` section from `posts/reboot/index.qmd` completely unnecessary.
+ Adds a post for 2023-12-06 meeting.