### PR TITLE
Adds pre-commit and updates README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting_setup.md
+++ b/.github/ISSUE_TEMPLATE/meeting_setup.md
@@ -47,14 +47,14 @@ Please check off tasks as complete and fill in fields with details for reference
   + **Lead** :
 + [ ] Identify paper of choice (for suggestions see [Zotero
       Group](https://www.zotero.org/groups/2354006/reproducibilitea/library)).
-  + **Paper** : [<TITLE>](<URL>)
+  + **Paper** : [TITLE](URL)
 + [ ] Create new web-page detailing paper.
   + [ ] Include a [OpenStreetMap](https://openstreetmap.org) link to the building location.
 + [ ] Create Google Calendar event with room details and link to web-page.
   + **Calendar Link** :
 + [ ] Create Event and News item on [OSC Sheffield](https://osc-international.com/osc-sheffield/)
-  + [ ] **Event** : [CALENDAR EVENT](<URL>)
-  + [ ] **News** : [NEWS EVENT](<URL>)
+  + [ ] **Event** : [CALENDAR EVENT](URL)
+  + [ ] **News** : [NEWS EVENT](URL)
 + [ ] Announce to mailing lists...
   + [ ] [reproducibilitea-googlegroup@sheffield.ac.uk](mailto:reproducibilitea-googlegroup@sheffield.ac.uk)
   + [ ] [rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk)

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,22 @@
+# Configuration
+
+config:
+
+# MD013 - line-length
+
+  line_length:
+    line_length: 120
+    code_blocks: false
+    tables: false
+  html:
+    allowed_elements:
+      - div
+globs:
+  - "posts/**/*.qmd"
+  - "*.qmd"
+ignores:
+  - "_site/**/*.qmd"
+
+# Fix any fixable errors
+
+fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,11 @@ repos:
     - id: check-yaml
     - id: check-added-large-files
       args: ['--maxkb=2048']
+    - id: mixed-line-ending
+    - id: check-merge-conflict
 
 - repo: https://github.com/DavidAnson/markdownlint-cli2
-  rev: v0.8.1
+  rev: v0.11.0
   hooks:
     - id: markdownlint-cli2
       args: []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repository is the source code for the [Reproducibilitea Sheffield](https://Reproducibilitea-Sheffield.github.io)
 website.
 
-
 ## Creating a new Post
 
 Typically you will have [booked a room](https://sites.google.com/sheffield.ac.uk/pooledroomdirectory/home) to hold the
@@ -53,6 +52,26 @@ Trying to stick with the Open Source theme, links to building locations can be p
 [OpenStreetMap](https://www.openstreetmap.org). Navigate, via zooming in, to the location of the building and
 right-click on the map and select "_Center map here_" and you can then copy the URL ("_Ctrl + l_" followed by "_Ctrl +
 c_" in most browsers) and paste that into the web-page you are creating.
+
+### pre-commit
+
+This repository uses [pre-commit](https://pre-commit.com) to check files and link Markdown using
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). If you are unfamiliar with Git Hooks and
+pre-commit a useful article is [Pre-Commit : Protecting your future self](https://ns-rse.github.io/posts/pre-commit/)
+(there are [subsequent posts on pre-commit](https://ns-rse.github.io/index.html#category=pre-commit)). Ideally you would
+install `pre-commit` locally using the included `.pre-commit-configy.yaml` and `.markdownlint-cli2.yaml` files and
+address issues before committing. If you don't do this locally the code will be checked when Pull Requests are made
+using [pre-commit.ci](https://pre-commit.ci). Where possible fixes will be made automatically but sometimes the linters
+can't fix all errors that they find. If this is the case the log-file from the linked check will explain what changes
+need to be made.
+
+## Meeting Setup
+
+There is an [issue
+   template](https://github.com/Reproducibilitea-Sheffield/Reproducibilitea-Sheffield.github.io/issues/new?assignees=&labels=meetings&projects=&template=meeting_setup.md&title=Prepare+session+on+%5BYYYY-MM-DD+HH%3Amm%5D+for+%5BLEAD+NAME%5D)
+for setting up new meetings that details all of the tasks that are required for setting up a Journal Club and
+advertising it. Where possible fill in details at creation time and tick off items (to tick of an item in Markdown put
+in `x` in the square brackets, i.e. `[x]`).
 
 ## Links
 

--- a/links.qmd
+++ b/links.qmd
@@ -49,7 +49,6 @@ search for articles to discuss. Find out more [here](https://reproducibilitea.or
 
 + [Journal of Open Source Software](https://joss.theoj.org/)
 
-
 ## Open Data
 
 + [FAIR Principles](https://www.force11.org/group/fairgroup/fairprinciples)

--- a/posts/2023-12/index.qmd
+++ b/posts/2023-12/index.qmd
@@ -40,7 +40,6 @@ The chosen article to that we review and discuss is a recent publication _Nature
 Neil Shephard (Research Software Engineer at University of Sheffield) will give a brief summary of the article and will
 open discussion by highlighting some of the points he thought were good/bad about the paper.
 
-
 ## Where
 
 This event will be hybrid, if you wish to attend in person we will be meeting in Workroom 2 of [The Diamond, 32


### PR DESCRIPTION
Closes #6

+ Introduces linting of Markdown via `pre-commit` and `markdownlint-cli2`.
+ Updates `README.md` with information on this as well as instructions on using the Issue Template to setup a meeting.
+ Lints existing code.